### PR TITLE
解决样式影响代码块首字母大小写的问题

### DIFF
--- a/hydrogen.scss
+++ b/hydrogen.scss
@@ -113,7 +113,7 @@ $icon-juejin: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAgCAYAAABg
   h2,
   h3,
   p {
-    &::first-letter {
+    &::first-letter:not(code) {
       text-transform: capitalize;
     }
   }


### PR DESCRIPTION
当 h2、h3、p 以代码块为开头时，代码里的第一个字母会被转成大写

由于这可能会造成歧义，建议避免

![image](https://user-images.githubusercontent.com/57293776/153759753-2d4ef80b-a7bd-4928-999d-26986fa30811.png)

![image](https://user-images.githubusercontent.com/57293776/153759789-c693985c-cfb1-4bec-b628-bdc3543f00e7.png)
